### PR TITLE
Pass in an empty object instead of NULL

### DIFF
--- a/src/android/TransitionNotificationReceiver.java
+++ b/src/android/TransitionNotificationReceiver.java
@@ -107,11 +107,11 @@ public class TransitionNotificationReceiver extends BroadcastReceiver {
         }
 
         if (eventName.equals(context.getString(R.string.transition_stop_tracking))) {
-                postNativeAndNotify(context, TRACKING_STOPPED, null);
+                postNativeAndNotify(context, TRACKING_STOPPED, new JSONObject());
         }
 
         if (eventName.equals(context.getString(R.string.transition_start_tracking))) {
-                postNativeAndNotify(context, TRACKING_STARTED, null);
+                postNativeAndNotify(context, TRACKING_STARTED, new JSONObject());
             }
         } catch (JSONException e) {
             e.printStackTrace();


### PR DESCRIPTION
For notifications for which we do not have user data, pass in an empty object
instead of NULL to avoid NPEs.

Thanks to @hassanobeid for reporting this issue and motivating me to fix it!