### PR TITLE
Support iOS 8.4 as well

### DIFF
--- a/www/ui/ionic/js/transition-notify-settings.js
+++ b/www/ui/ionic/js/transition-notify-settings.js
@@ -117,8 +117,11 @@ angular.module('emission.main.control.tnotify', [])
 
     ctnh.saveAndReload = function() {
         console.log("new config = "+ctnh.editedDisplayConfig);
-        var promiseList = Array.from(ctnh.toggledSet)
-                                .map(function(currConfigWrapper) {
+        var toggledArray = [];
+        ctnh.toggledSet.forEach(function(v) {
+            toggledArray.push(v);
+        });
+        var promiseList = toggledArray.map(function(currConfigWrapper) {
             // TODO: I think we can use apply here since these are
             // basically the fields.
             return ctnh.setEnabled(currConfigWrapper.transitionName, 


### PR DESCRIPTION
It doesn't support `Array.from`, so fill in values using `forEach`.
https://stackoverflow.com/questions/20069828/how-to-convert-set-to-array#20070691