### PR TITLE
Add a check to see if we are initializing the state machine recursively

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.transitionnotify"
-        version="1.2.1">
+        version="1.2.2">
 
   <name>TransitionNotification</name>
   <description>Transition notification. Specially good for trip start and trip end notifications </description>

--- a/src/ios/BEMTransitionNotifier.m
+++ b/src/ios/BEMTransitionNotifier.m
@@ -52,6 +52,11 @@
 - (void)fireGenericTransitionFor:(NSString*) transition withUserInfo:(NSDictionary*) userInfo {
     [LocalNotificationManager addNotification:[NSString stringWithFormat:@"Received platform-specific notification %@", transition] showUI:FALSE];
 
+    TripDiaryStateMachine* instance = [TripDiaryStateMachine instance];
+    if (instance == NULL) {
+        [LocalNotificationManager addNotification:@"Unable to access state machine instance, must be recursive call on startup, bailing"];
+        return;
+    }
     if ([TripDiaryStateMachine instance].currState == kWaitingForTripStartState &&
             ([transition isEqualToString:CFCTransitionExitedGeofence] ||
              [transition isEqualToString:CFCTransitionVisitEnded])) {


### PR DESCRIPTION
If we are, this will return NULL and we skip the translation since it is
unlikely to be a real transition anyway.

This is part of the fix - the other part has already been checked into the data collector.
The matching PR is https://github.com/e-mission/e-mission-data-collection/pull/181

This fixes https://github.com/e-mission/e-mission-transition-notify/issues/18