### PR TITLE
Handle two minor issues that caused us to crash on `removeEventListener`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.transitionnotify"
-        version="1.2.4">
+        version="1.2.5">
 
   <name>TransitionNotification</name>
   <description>Transition notification. Specially good for trip start and trip end notifications </description>

--- a/src/ios/BEMTransitionNotifier.m
+++ b/src/ios/BEMTransitionNotifier.m
@@ -292,7 +292,7 @@
     }
     NSUInteger existingIndex = [currList indexOfObjectPassingTest:^BOOL(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         // Note that the id is a long so == works. If we assume that it is a string, we would need to use isEqualToString
-        return obj[@"id"] == localNotifyConfig[@"id"];
+        return [obj[@"id"] isEqualToNumber:localNotifyConfig[@"id"]];
     }];
     return existingIndex;
 }
@@ -352,7 +352,7 @@
     if (configWrapper != NULL) { // There is an existing entry for this event
         NSMutableArray* currList = configWrapper[listName];
         NSUInteger existingIndex = [self findIndex:localNotifyConfig fromList:currList];
-        if (existingIndex != -1) { // There is an existing entry for this ID
+        if (existingIndex != NSNotFound) { // There is an existing entry for this ID
             [LocalNotificationManager addNotification:[NSString stringWithFormat:@"removed obsolete notification at %lu", existingIndex]];
             [currList removeObjectAtIndex:existingIndex];
             if ([currList count] == 0) { // list size is now zero


### PR DESCRIPTION
- Since the `NSDictionary` created by parsing the incoming JSON converts
  numbers to `NSNumber` objects, we need to use `isEqualToNumber`
- and when we don't find matches, the `findIndex` method now returns
  `NSNotFound`, not `-1`. If we don't make the correct check, we try to remove
  the entry at `NSNotFound` which crashes.

Each of them is a one line fix.
Also bump up the version number.

Testing done (on iOS 13):
- add event with id 737678
- delete event with id 737678 <- event is removed, no crash
- delete event with id 737678 again <- event does not exist, no crash
- re-add event with id 737678
- delete event with id 737679 <- event is not removed, no crash

This fixes #27