### PR TITLE
Convert NSAsserts to log client error stats

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-transition-notify"
-        version="1.2.6">
+        version="1.2.7">
 
   <name>TransitionNotification</name>
   <description>Transition notification. Specially good for trip start and trip end notifications </description>


### PR DESCRIPTION
This is a fix for the first issue in
https://github.com/e-mission/e-mission-docs/issues/722
notably, converting all the asserts to stats so that the app won't crash
https://github.com/e-mission/e-mission-docs/issues/722#issuecomment-1110075053
and returning NULL from those conditions

The new stats names are stored in the `cordova-usercache` plugin